### PR TITLE
Update Xfinity OAuth URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ inherits(iControl, EventEmitter);
 
 iControl.Systems = {
   XFINITY_HOME: {
-    oauthLoginURL: "https://login.comcast.net/oauth/",
+    oauthLoginURL: "https://oauth.xfinity.com/oauth/",
     clientID: "Xfinity-Home-iOS-App",
     clientSecret: "77b366f9a135c7ab391044234a26b1d6b1e08f66",
     clientRedirect: "xfinityhome://auth",


### PR DESCRIPTION
The old URL would redirect to another page before redirecting to the
login page. The code here assumes a single redirect so would not find
a login form to fill out.