### PR TITLE
Updated to work with current Xfinity API and login URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -467,8 +467,6 @@ iControl.prototype._makeAuthenticatedRequest = function(req, callback) {
   req.headers['X-Session'] = this._sessionToken;
 
   request(req, function(err, response, body) {
-    console.log(err);
-    console.log(response);
     if (!err && response.statusCode == 200 && response.headers['content-type'].indexOf('json') != -1) {
       callback(null, JSON.parse(body));
     }

--- a/index.js
+++ b/index.js
@@ -57,22 +57,6 @@ iControl.ArmState = {
   ARMED_STAY: "stay"
 }
 
-iControl.prototype.test = function() {
-  
-  //use existing accessToken
-  if (this._accessToken && (this._nowTime < this._accessTokenExpiresAt)) {
-    console.log("Using existing access token.");
-    this._activateRestAPI();
-    return;
-  }
-  else if (this._refreshToken) { // try to use the refresh token if we have one; skip the really slow login process
-    console.log("Getting new access token with refresh token.");
-    this._getAccessToken(null);
-    return;
-  }
-
-}
-
 iControl.prototype.getArmState = function(callback) {
   debug("Requesting current arm state..");
   // API changed to get arm status and all devices, etc from one single API request while logging in.
@@ -317,12 +301,12 @@ iControl.prototype._getAccessToken = function(authorizationCode, callback = null
 
   // use a authorizationCode if given, otherwise use our refresh token
   if (authorizationCode) {
-    console.log("Logging in with authorization code from web form...");
+    debug("Logging in with authorization code from web form...");
     form.code = authorizationCode;
     form.grant_type = "authorization_code";
   }
   else {
-    console.log("Logging in with previously stored refresh token...");
+    debug("Logging in with previously stored refresh token...");
     form.refresh_token = this._refreshToken;
     form.grant_type = "refresh_token";
   }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ iControl.ArmState = {
 }
 
 iControl.prototype.getArmState = function(callback) {
-  debug.enabled = true;
   debug("Requesting current arm state..");
   // API changed to get arm status and all devices, etc from one single API request while logging in.
   this._activateRestAPI(function(armState) {
@@ -150,7 +149,6 @@ iControl.prototype.subscribeEvents = function(callback) {
  */
 
  iControl.prototype.login = function(callback) {
-   debug.enabled = true;
    // queue this callback for when we're finished logging in
    if (callback)
      this._loginCompleteCallbacks.push(callback);
@@ -171,14 +169,12 @@ iControl.prototype.subscribeEvents = function(callback) {
 
 iControl.prototype._beginLogin = function(callback = null) { //Callbacks bubble up so that _activateRestAPI can maintain a callback during a status request
 
-  // Disabled for now - iControl's new API endpoint doesn't seem to work well
-  // with access tokens that weren't generated *just now*.
-
-  // if (this._accessToken) {
-  //   debug("Using existing access token.");
-  //   this._activateRestAPI();
-  //   return;
-  // }
+  //use existing accessToken
+  if (this._accessToken) {
+    debug("Using existing access token.");
+    this._activateRestAPI();
+    return;
+  }
 
   // try to use the refresh token if we have one; skip the really slow login process
   if (this._refreshToken) {
@@ -363,9 +359,6 @@ iControl.prototype._getAccessToken = function(authorizationCode, callback = null
 iControl.prototype._activateRestAPI = function(callback = null) {
 
   var url = this.system.restAPI + "client";
-  //var form = { user_access: this._accessToken };
-  //console.log('ACCESS TOKEN:', this._accessToken);
-  // debug(url);
 
   var opts = {
     url: url,
@@ -381,8 +374,6 @@ iControl.prototype._activateRestAPI = function(callback = null) {
   request.get(url, opts, function(err, response, body) {
     if (!err && response.statusCode == 200) {
       this._sessionToken = response.headers["x-session"];
-      
-      
 
       /* expecting a response like:
       {

--- a/index.js
+++ b/index.js
@@ -44,8 +44,7 @@ iControl.Systems = {
     clientID: "Xfinity-Home-iOS-App",
     clientSecret: "77b366f9a135c7ab391044234a26b1d6b1e08f66",
     clientRedirect: "xfinityhome://auth",
-    restAPI: "https://xhomeapi-lb-prod.codebig2.net/" //https://homesecurity-prod.codebig2.net/rest/
-    //https://xhomeapi-lb-prod.codebig2.net/client/
+    restAPI: "https://xhomeapi-lb-prod.codebig2.net/"
   }
 }
 
@@ -59,20 +58,10 @@ iControl.ArmState = {
 iControl.prototype.getArmState = function(callback) {
   debug.enabled = true;
   debug("Requesting current arm state..");
-
+  // API changed to get arm status and all devices, etc from one single API request while logging in.
   this._activateRestAPI(function(armState) {
     callback(null, armState);
-  }); //can start from here since all we need to know is the data from the initial request
- 
-  // this._makeAuthenticatedRequest({path: "site/:site/device/panel/:panel"}, function(err, panel) {
-  //   if (err) return callback && callback(err);
-
-  //   var armType = panel.properties.armType; // "away", "night", "stay", or null (disarmed)
-  //   var armState = armType || "disarmed";
-  //   debug("Retrieved current arm state: %s", armState);
-  //   callback(null, armState);
-
-  // }.bind(this));
+  });
 }
 
 iControl.prototype.setArmState = function(armState, callback) {
@@ -180,7 +169,7 @@ iControl.prototype.subscribeEvents = function(callback) {
    this._loginCompleteCallbacks = [];
  }
 
-iControl.prototype._beginLogin = function(callback = null) {
+iControl.prototype._beginLogin = function(callback = null) { //Callbacks bubble up so that _activateRestAPI can maintain a callback during a status request
 
   // Disabled for now - iControl's new API endpoint doesn't seem to work well
   // with access tokens that weren't generated *just now*.
@@ -192,10 +181,10 @@ iControl.prototype._beginLogin = function(callback = null) {
   // }
 
   // try to use the refresh token if we have one; skip the really slow login process
-  // if (this._refreshToken) {
-  //   this._getAccessToken(null);
-  //   return;
-  // }
+  if (this._refreshToken) {
+    this._getAccessToken(null);
+    return;
+  }
 
   var url = this.system.oauthLoginURL + "authorize";
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "wylanswets-icontrol",
+  "name": "node-icontrol",
   "description": "NodeJS module for controlling an iControl security system (like Xfinity Home)",
-  "version": "0.2.5",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/wylanswets/icontrol.git"
+    "url": "git@github.com:nfarina/icontrol.git"
   },
   "license": "MIT",
   "dependencies": {
@@ -12,17 +12,5 @@
     "node-persist": "0.0.x",
     "request": "^2.81.0",
     "ws": "^0.8.0"
-  },
-  "bugs": {
-    "url": "https://github.com/wylanswets/icontrol/issues"
-  },
-  "homepage": "https://github.com/nfarina/icontrol#readme",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [
-    "homebridge"
-  ],
-  "author": "Wylan Swets"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "node-icontrol",
+  "name": "wylanswets-icontrol",
   "description": "NodeJS module for controlling an iControl security system (like Xfinity Home)",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
-    "url": "git@github.com:nfarina/icontrol.git"
+    "url": "git+ssh://git@github.com/wylanswets/icontrol.git"
   },
   "license": "MIT",
   "dependencies": {
@@ -12,5 +12,17 @@
     "node-persist": "0.0.x",
     "request": "^2.81.0",
     "ws": "^0.8.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/wylanswets/icontrol/issues"
+  },
+  "homepage": "https://github.com/nfarina/icontrol#readme",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "homebridge"
+  ],
+  "author": "Wylan Swets"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wylanswets-icontrol",
   "description": "NodeJS module for controlling an iControl security system (like Xfinity Home)",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/wylanswets/icontrol.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wylanswets-icontrol",
   "description": "NodeJS module for controlling an iControl security system (like Xfinity Home)",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/wylanswets/icontrol.git"


### PR DESCRIPTION
I've tested this in my homebridge environment as I've worked on it. I'm going to deploy it now to my home environment and continue to work on it if there are issues as I plan on making use of this ongoing.

Major changes in the API are:
During the login process, they only make one single call to restAPI url "/client" which returns a massive JSON payload. The changes I had to make include:
- Now only 1 site is ever returned at the root of the JSON object
- The devices are returned right in the JSON as well, including the panel and arm status
- Arm status is only fetched in this initial payload so getting status means we need to fetch this "initial" payload again.
- Arm / Disarm commands are somewhat "less" restful while also being "more" restful. They submit to a generic path but in the request you have to add some strange looking path that comes in with the panel device in the initial payload. If you read the code changes you'll know what I mean but it looks like it is an "upgrade" from the old way.

I'm not sure if subscribeEvents is needed or how it was used previously, but I'm not going to touch it as I don't think it's used in HomeBridge anyway. This also means it probably will not work anymore since the API is so drastically different now and I didn't check if they even support websockets now.

